### PR TITLE
Feat/add country

### DIFF
--- a/di/container.ts
+++ b/di/container.ts
@@ -1,7 +1,9 @@
 import { countriesModule } from './modules/countries.module';
+import { authModule } from './modules/auth.module';
 import { createContainer } from '@evyweb/ioctopus';
 import { Registry } from './types';
 
 export const container = createContainer<Registry>();
 
 container.load('countriesModule', countriesModule());
+container.load('authModule', authModule());

--- a/di/container.ts
+++ b/di/container.ts
@@ -1,7 +1,6 @@
+import { countriesModule } from './modules/countries.module';
 import { createContainer } from '@evyweb/ioctopus';
 import { Registry } from './types';
-import { countriesModule } from './modules/countries.module';
-
 
 export const container = createContainer<Registry>();
 

--- a/di/container.ts
+++ b/di/container.ts
@@ -1,0 +1,8 @@
+import { createContainer } from '@evyweb/ioctopus';
+import { Registry } from './types';
+import { countriesModule } from './modules/countries.module';
+
+
+export const container = createContainer<Registry>();
+
+container.load('countriesModule', countriesModule());

--- a/di/modules/auth.module.ts
+++ b/di/modules/auth.module.ts
@@ -1,0 +1,17 @@
+import { MockAuthenticationService } from '@/src/infrastructure/services/auth.service.mock';
+import { createModule } from '@evyweb/ioctopus';
+import { DI_SYMBOLS } from '../types';
+
+export function authModule() {
+    const authModule = createModule();
+
+    if (process.env.NODE_ENV === 'test') {
+        authModule
+            .bind(DI_SYMBOLS.IAuthenticationService)
+            .toClass(MockAuthenticationService);
+    } else {
+        throw new Error('No real authentication service implemented yet.');
+    }
+
+    return authModule;
+}

--- a/di/modules/auth.module.ts
+++ b/di/modules/auth.module.ts
@@ -1,4 +1,4 @@
-import { MockAuthenticationService } from '@/src/infrastructure/services/auth.service.mock';
+import { MockAuthenticationService } from '@/infrastructure/services/auth.service.mock';
 import { createModule } from '@evyweb/ioctopus';
 import { DI_SYMBOLS } from '../types';
 

--- a/di/modules/countries.module.ts
+++ b/di/modules/countries.module.ts
@@ -1,18 +1,23 @@
 import { createCountryController } from '@/src/interface-adapters/controllers/create-country.controller';
+import { MockCountriesRepository } from '@/src/infrastructure/repositories/countries.repository.mock';
 import { createCountryUseCase } from '@/src/application/use-cases/create-country.use-case';
-import { CountriesRepositoryMock } from '@/src/infrastructure/countries.repository.mock';
 import { createModule } from '@evyweb/ioctopus';
 import { DI_SYMBOLS } from '../types';
 
 export function countriesModule() {
     const countriesModule = createModule();
-    countriesModule
-        .bind(DI_SYMBOLS.ICountryRepository)
-        .toClass(CountriesRepositoryMock);
+    if (process.env.NODE_ENV === 'test') {
+        countriesModule
+            .bind(DI_SYMBOLS.ICountryRepository)
+            .toClass(MockCountriesRepository);
+    } else {
+        throw new Error('No real countries repository implemented yet.');
+    }
     countriesModule
         .bind(DI_SYMBOLS.ICreateCountryController)
         .toHigherOrderFunction(createCountryController, [
             DI_SYMBOLS.ICreateCountryUseCase,
+            DI_SYMBOLS.IAuthenticationService,
         ]);
     countriesModule
         .bind(DI_SYMBOLS.ICreateCountryUseCase)

--- a/di/modules/countries.module.ts
+++ b/di/modules/countries.module.ts
@@ -8,7 +8,7 @@ export function countriesModule() {
     const countriesModule = createModule();
     if (process.env.NODE_ENV === 'test') {
         countriesModule
-            .bind(DI_SYMBOLS.ICountryRepository)
+            .bind(DI_SYMBOLS.ICountriesRepository)
             .toClass(MockCountriesRepository);
     } else {
         throw new Error('No real countries repository implemented yet.');

--- a/di/modules/countries.module.ts
+++ b/di/modules/countries.module.ts
@@ -1,8 +1,8 @@
-import { createCountryUseCase } from "@/src/application/use-cases/create-country.use-case";
-import { CountriesRepositoryMock } from "@/src/infrastructure/countries.repository.mock";
-import { createCountryController } from "@/src/interface-adapters/controllers/create-country.controller";
-import { createModule } from "@evyweb/ioctopus";
-import { DI_SYMBOLS } from "../types";
+import { createCountryController } from '@/src/interface-adapters/controllers/create-country.controller';
+import { createCountryUseCase } from '@/src/application/use-cases/create-country.use-case';
+import { CountriesRepositoryMock } from '@/src/infrastructure/countries.repository.mock';
+import { createModule } from '@evyweb/ioctopus';
+import { DI_SYMBOLS } from '../types';
 
 export function countriesModule() {
     const countriesModule = createModule();

--- a/di/modules/countries.module.ts
+++ b/di/modules/countries.module.ts
@@ -22,7 +22,7 @@ export function countriesModule() {
     countriesModule
         .bind(DI_SYMBOLS.ICreateCountryUseCase)
         .toHigherOrderFunction(createCountryUseCase, [
-            DI_SYMBOLS.ICountryRepository,
+            DI_SYMBOLS.ICountriesRepository,
         ]);
     return countriesModule;
 }

--- a/di/modules/countries.module.ts
+++ b/di/modules/countries.module.ts
@@ -1,6 +1,6 @@
-import { createCountryController } from '@/src/interface-adapters/controllers/create-country.controller';
-import { MockCountriesRepository } from '@/src/infrastructure/repositories/countries.repository.mock';
-import { createCountryUseCase } from '@/src/application/use-cases/create-country.use-case';
+import { createCountryController } from '@/interface-adapters/controllers/create-country.controller';
+import { MockCountriesRepository } from '@/infrastructure/repositories/countries.repository.mock';
+import { createCountryUseCase } from '@/application/use-cases/create-country.use-case';
 import { createModule } from '@evyweb/ioctopus';
 import { DI_SYMBOLS } from '../types';
 

--- a/di/modules/countries.module.ts
+++ b/di/modules/countries.module.ts
@@ -1,0 +1,23 @@
+import { createCountryUseCase } from "@/src/application/use-cases/create-country.use-case";
+import { CountriesRepositoryMock } from "@/src/infrastructure/countries.repository.mock";
+import { createCountryController } from "@/src/interface-adapters/controllers/create-country.controller";
+import { createModule } from "@evyweb/ioctopus";
+import { DI_SYMBOLS } from "../types";
+
+export function countriesModule() {
+    const countriesModule = createModule();
+    countriesModule
+        .bind(DI_SYMBOLS.ICountryRepository)
+        .toClass(CountriesRepositoryMock);
+    countriesModule
+        .bind(DI_SYMBOLS.ICreateCountryController)
+        .toHigherOrderFunction(createCountryController, [
+            DI_SYMBOLS.ICreateCountryUseCase,
+        ]);
+    countriesModule
+        .bind(DI_SYMBOLS.ICreateCountryUseCase)
+        .toHigherOrderFunction(createCountryUseCase, [
+            DI_SYMBOLS.ICountryRepository,
+        ]);
+    return countriesModule;
+}

--- a/di/types.ts
+++ b/di/types.ts
@@ -1,15 +1,32 @@
 import { ICreateCountryController } from '@/src/interface-adapters/controllers/create-country.controller';
 import { ICountriesRepository } from '@/src/application/repositories/countries.repository.interface';
 import { ICreateCountryUseCase } from '@/src/application/use-cases/create-country.use-case';
+import { IAuthenticationService } from '@/src/application/services/auth.service.interface';
 
 export const DI_SYMBOLS = {
+    // Services
+    IAuthenticationService: Symbol.for('IAuthenticationService'),
+
+    // Repositories
     ICountryRepository: Symbol.for('ICountryRepository'),
+
+    // Use Cases
     ICreateCountryUseCase: Symbol.for('ICreateCountryUseCase'),
+
+    // Controllers
     ICreateCountryController: Symbol.for('ICreateCountryController'),
 };
 
 export interface Registry {
+    // Services
+    [DI_SYMBOLS.IAuthenticationService]: IAuthenticationService;
+
+    // Repositories
     [DI_SYMBOLS.ICountryRepository]: ICountriesRepository;
-    [DI_SYMBOLS.ICreateCountryController]: ICreateCountryController;
+
+    // Use Cases
     [DI_SYMBOLS.ICreateCountryUseCase]: ICreateCountryUseCase;
+
+    // Controllers
+    [DI_SYMBOLS.ICreateCountryController]: ICreateCountryController;
 }

--- a/di/types.ts
+++ b/di/types.ts
@@ -1,0 +1,15 @@
+import { ICreateCountryController } from '@/src/interface-adapters/controllers/create-country.controller';
+import { ICreateCountryUseCase } from '@/src/application/use-cases/create-country.use-case';
+import { ICountriesRepository } from '@/src/application/repositories/countries.repository.interface';
+
+export const DI_SYMBOLS = {
+    ICountryRepository: Symbol.for('ICountryRepository'),
+    ICreateCountryUseCase: Symbol.for('ICreateCountryUseCase'),
+    ICreateCountryController: Symbol.for('ICreateCountryController'),
+};
+
+export interface Registry {
+    [DI_SYMBOLS.ICountryRepository]: ICountriesRepository;
+    [DI_SYMBOLS.ICreateCountryController]: ICreateCountryController;
+    [DI_SYMBOLS.ICreateCountryUseCase]: ICreateCountryUseCase;
+}

--- a/di/types.ts
+++ b/di/types.ts
@@ -8,7 +8,7 @@ export const DI_SYMBOLS = {
     IAuthenticationService: Symbol.for('IAuthenticationService'),
 
     // Repositories
-    ICountryRepository: Symbol.for('ICountryRepository'),
+    ICountriesRepository: Symbol.for('ICountriesRepository'),
 
     // Use Cases
     ICreateCountryUseCase: Symbol.for('ICreateCountryUseCase'),
@@ -22,7 +22,7 @@ export interface Registry {
     [DI_SYMBOLS.IAuthenticationService]: IAuthenticationService;
 
     // Repositories
-    [DI_SYMBOLS.ICountryRepository]: ICountriesRepository;
+    [DI_SYMBOLS.ICountriesRepository]: ICountriesRepository;
 
     // Use Cases
     [DI_SYMBOLS.ICreateCountryUseCase]: ICreateCountryUseCase;

--- a/di/types.ts
+++ b/di/types.ts
@@ -1,6 +1,6 @@
 import { ICreateCountryController } from '@/src/interface-adapters/controllers/create-country.controller';
-import { ICreateCountryUseCase } from '@/src/application/use-cases/create-country.use-case';
 import { ICountriesRepository } from '@/src/application/repositories/countries.repository.interface';
+import { ICreateCountryUseCase } from '@/src/application/use-cases/create-country.use-case';
 
 export const DI_SYMBOLS = {
     ICountryRepository: Symbol.for('ICountryRepository'),

--- a/di/types.ts
+++ b/di/types.ts
@@ -1,7 +1,7 @@
-import { ICreateCountryController } from '@/src/interface-adapters/controllers/create-country.controller';
-import { ICountriesRepository } from '@/src/application/repositories/countries.repository.interface';
-import { ICreateCountryUseCase } from '@/src/application/use-cases/create-country.use-case';
-import { IAuthenticationService } from '@/src/application/services/auth.service.interface';
+import { ICreateCountryController } from '@/interface-adapters/controllers/create-country.controller';
+import { ICountriesRepository } from '@/application/repositories/countries.repository.interface';
+import { ICreateCountryUseCase } from '@/application/use-cases/create-country.use-case';
+import { IAuthenticationService } from '@/application/services/auth.service.interface';
 
 export const DI_SYMBOLS = {
     // Services

--- a/di/types.ts
+++ b/di/types.ts
@@ -1,7 +1,7 @@
-import { ICreateCountryController } from '@/interface-adapters/controllers/create-country.controller';
-import { ICountriesRepository } from '@/application/repositories/countries.repository.interface';
-import { ICreateCountryUseCase } from '@/application/use-cases/create-country.use-case';
-import { IAuthenticationService } from '@/application/services/auth.service.interface';
+import type { ICreateCountryController } from '@/interface-adapters/controllers/create-country.controller';
+import type { ICountriesRepository } from '@/application/repositories/countries.repository.interface';
+import type { ICreateCountryUseCase } from '@/application/use-cases/create-country.use-case';
+import type { IAuthenticationService } from '@/application/services/auth.service.interface';
 
 export const DI_SYMBOLS = {
     // Services

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "prettier-plugin-tailwindcss": "^0.6.14",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "tailwind-merge": "^3.3.1"
+        "tailwind-merge": "^3.3.1",
+        "zod": "^4.1.11"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -6708,6 +6709,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "prettier-plugin-tailwindcss": "^0.6.14",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "zod": "^4.1.11"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/application/repositories/countries.repository.interface.ts
+++ b/src/application/repositories/countries.repository.interface.ts
@@ -1,0 +1,6 @@
+import { Country, CountryInsert } from '@/src/entities/models/country';
+
+export interface ICountriesRepository {
+    createCountry(country: CountryInsert): Promise<Country>;
+    getAllCountries(): Promise<Country[]>;
+}

--- a/src/application/repositories/countries.repository.interface.ts
+++ b/src/application/repositories/countries.repository.interface.ts
@@ -1,4 +1,4 @@
-import { Country, CountryInsert } from '@/src/entities/models/country';
+import { Country, CountryInsert } from '@/entities/models/country';
 
 export interface ICountriesRepository {
     createCountry(country: CountryInsert): Promise<Country>;

--- a/src/application/services/auth.service.interface.ts
+++ b/src/application/services/auth.service.interface.ts
@@ -1,0 +1,5 @@
+export interface IAuthenticationService {
+    validateSession(sessionId: string): Promise<boolean>;
+    createSession(userId: string): Promise<string>;
+    invalidateSession(sessionId: string): Promise<boolean>;
+}

--- a/src/application/use-cases/create-country.use-case.ts
+++ b/src/application/use-cases/create-country.use-case.ts
@@ -1,5 +1,4 @@
 import { ICountriesRepository } from '../repositories/countries.repository.interface';
-import { InputParseError } from '@/src/entities/errors/common';
 import { Country } from '@/src/entities/models/country';
 
 export type ICreateCountryUseCase = ReturnType<typeof createCountryUseCase>;
@@ -8,13 +7,6 @@ export const createCountryUseCase =
     (countryRepository: ICountriesRepository) =>
     async (name: string): Promise<Country> => {
         // HINT: this is where you'd do authorization checks - is this user authorized to create a country
-
-        // business logic input check
-        if (name.length < 1) {
-            throw new InputParseError(
-                'Country name must be at least 1 character long.',
-            );
-        }
 
         return countryRepository.createCountry({ name });
     };

--- a/src/application/use-cases/create-country.use-case.ts
+++ b/src/application/use-cases/create-country.use-case.ts
@@ -8,5 +8,7 @@ export const createCountryUseCase =
     async (name: string): Promise<Country> => {
         // HINT: this is where you'd do authorization checks - is this user authorized to create a country
 
+        // HINT: this is where you'd do validation - is the country name valid, does it already exist, etc.
+
         return countryRepository.createCountry({ name });
     };

--- a/src/application/use-cases/create-country.use-case.ts
+++ b/src/application/use-cases/create-country.use-case.ts
@@ -1,5 +1,5 @@
 import { ICountriesRepository } from '../repositories/countries.repository.interface';
-import { Country } from '@/src/entities/models/country';
+import { Country } from '@/entities/models/country';
 
 export type ICreateCountryUseCase = ReturnType<typeof createCountryUseCase>;
 

--- a/src/application/use-cases/create-country.use-case.ts
+++ b/src/application/use-cases/create-country.use-case.ts
@@ -5,8 +5,6 @@ export type ICreateCountryUseCase = ReturnType<typeof createCountryUseCase>;
 
 export const createCountryUseCase =
     (countryRepository: ICountriesRepository) =>
-    async  (name: string): Promise<Country> => {
-        
-        return countryRepository.createCountry({name});
-        
+    async (name: string): Promise<Country> => {
+        return countryRepository.createCountry({ name });
     };

--- a/src/application/use-cases/create-country.use-case.ts
+++ b/src/application/use-cases/create-country.use-case.ts
@@ -1,0 +1,12 @@
+import { ICountriesRepository } from '../repositories/countries.repository.interface';
+import { Country } from '@/src/entities/models/country';
+
+export type ICreateCountryUseCase = ReturnType<typeof createCountryUseCase>;
+
+export const createCountryUseCase =
+    (countryRepository: ICountriesRepository) =>
+    async  (name: string): Promise<Country> => {
+        
+        return countryRepository.createCountry({name});
+        
+    };

--- a/src/application/use-cases/create-country.use-case.ts
+++ b/src/application/use-cases/create-country.use-case.ts
@@ -1,4 +1,5 @@
 import { ICountriesRepository } from '../repositories/countries.repository.interface';
+import { InputParseError } from '@/src/entities/errors/common';
 import { Country } from '@/src/entities/models/country';
 
 export type ICreateCountryUseCase = ReturnType<typeof createCountryUseCase>;
@@ -6,5 +7,14 @@ export type ICreateCountryUseCase = ReturnType<typeof createCountryUseCase>;
 export const createCountryUseCase =
     (countryRepository: ICountriesRepository) =>
     async (name: string): Promise<Country> => {
+        // HINT: this is where you'd do authorization checks - is this user authorized to create a country
+
+        // business logic input check
+        if (name.length < 1) {
+            throw new InputParseError(
+                'Country name must be at least 1 character long.',
+            );
+        }
+
         return countryRepository.createCountry({ name });
     };

--- a/src/entities/errors/auth.ts
+++ b/src/entities/errors/auth.ts
@@ -1,0 +1,17 @@
+export class AuthenticationError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+  }
+}
+
+export class UnauthenticatedError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+  }
+}
+
+export class UnauthorizedError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+  }
+}

--- a/src/entities/errors/auth.ts
+++ b/src/entities/errors/auth.ts
@@ -1,17 +1,17 @@
 export class AuthenticationError extends Error {
-  constructor(message: string, options?: ErrorOptions) {
-    super(message, options);
-  }
+    constructor(message: string, options?: ErrorOptions) {
+        super(message, options);
+    }
 }
 
 export class UnauthenticatedError extends Error {
-  constructor(message: string, options?: ErrorOptions) {
-    super(message, options);
-  }
+    constructor(message: string, options?: ErrorOptions) {
+        super(message, options);
+    }
 }
 
 export class UnauthorizedError extends Error {
-  constructor(message: string, options?: ErrorOptions) {
-    super(message, options);
-  }
+    constructor(message: string, options?: ErrorOptions) {
+        super(message, options);
+    }
 }

--- a/src/entities/errors/common.ts
+++ b/src/entities/errors/common.ts
@@ -1,0 +1,5 @@
+export class InputParseError extends Error {
+    constructor(message: string, options?: ErrorOptions) {
+        super(message, options);
+    }
+}

--- a/src/entities/models/country.ts
+++ b/src/entities/models/country.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const countrySchema = z.object({
+    id: z.string().min(2).max(2),
+    name: z.string().min(1).max(100),
+});
+
+export type Country = z.infer<typeof countrySchema>;
+
+export const insertCountrySchema = countrySchema.pick({ name: true });
+
+export type CountryInsert = z.infer<typeof insertCountrySchema>;

--- a/src/entities/models/country.ts
+++ b/src/entities/models/country.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export const countrySchema = z.object({
-    id: z.string().min(2).max(2),
+    id: z.string().min(1).max(3),
     name: z.string().min(1).max(100),
 });
 

--- a/src/infrastructure/countries.repository.mock.ts
+++ b/src/infrastructure/countries.repository.mock.ts
@@ -1,0 +1,21 @@
+import { ICountriesRepository } from '../application/repositories/countries.repository.interface';
+import { CountryInsert, Country } from '../entities/models/country';
+
+export class CountriesRepositoryMock implements ICountriesRepository {
+    private _countries: Country[];
+
+    constructor() {
+        this._countries = [];
+    }
+
+    async createCountry(country: CountryInsert): Promise<Country> {
+        const id = this._countries.length.toString();
+        const created = { id, ...country };
+        this._countries.push(created);
+        return created;
+    }
+
+    async getAllCountries(): Promise<Country[]> {
+        return this._countries;
+    }
+}

--- a/src/infrastructure/repositories/countries.repository.mock.ts
+++ b/src/infrastructure/repositories/countries.repository.mock.ts
@@ -1,7 +1,7 @@
 import { ICountriesRepository } from '../../application/repositories/countries.repository.interface';
 import { CountryInsert, Country } from '../../entities/models/country';
 
-export class CountriesRepositoryMock implements ICountriesRepository {
+export class MockCountriesRepository implements ICountriesRepository {
     private _countries: Country[];
 
     constructor() {

--- a/src/infrastructure/repositories/countries.repository.mock.ts
+++ b/src/infrastructure/repositories/countries.repository.mock.ts
@@ -1,5 +1,5 @@
-import { ICountriesRepository } from '../application/repositories/countries.repository.interface';
-import { CountryInsert, Country } from '../entities/models/country';
+import { ICountriesRepository } from '../../application/repositories/countries.repository.interface';
+import { CountryInsert, Country } from '../../entities/models/country';
 
 export class CountriesRepositoryMock implements ICountriesRepository {
     private _countries: Country[];

--- a/src/infrastructure/services/auth.service.mock.ts
+++ b/src/infrastructure/services/auth.service.mock.ts
@@ -1,0 +1,17 @@
+import { IAuthenticationService } from '@/src/application/services/auth.service.interface';
+
+export class MockAuthenticationService implements IAuthenticationService {
+    private userMap: Map<string, string> = new Map(); // sessionId -> userId
+
+    async validateSession(sessionId: string): Promise<boolean> {
+        return this.userMap.has(sessionId);
+    }
+    async createSession(userId: string): Promise<string> {
+        const sessionId = `session-${Math.random().toString(36)}`;
+        this.userMap.set(sessionId, userId);
+        return sessionId;
+    }
+    async invalidateSession(sessionId: string): Promise<boolean> {
+        return this.userMap.delete(sessionId);
+    }
+}

--- a/src/infrastructure/services/auth.service.mock.ts
+++ b/src/infrastructure/services/auth.service.mock.ts
@@ -1,4 +1,4 @@
-import { IAuthenticationService } from '@/src/application/services/auth.service.interface';
+import { IAuthenticationService } from '@/application/services/auth.service.interface';
 
 export class MockAuthenticationService implements IAuthenticationService {
     private userMap: Map<string, string> = new Map(); // sessionId -> userId

--- a/src/infrastructure/services/auth.service.mock.ts
+++ b/src/infrastructure/services/auth.service.mock.ts
@@ -1,4 +1,4 @@
-import { IAuthenticationService } from '@/application/services/auth.service.interface';
+import type { IAuthenticationService } from '@/application/services/auth.service.interface';
 
 export class MockAuthenticationService implements IAuthenticationService {
     private userMap: Map<string, string> = new Map(); // sessionId -> userId

--- a/src/interface-adapters/controllers/create-country.controller.ts
+++ b/src/interface-adapters/controllers/create-country.controller.ts
@@ -1,8 +1,8 @@
-import { ICreateCountryUseCase } from '@/src/application/use-cases/create-country.use-case';
-import { IAuthenticationService } from '@/src/application/services/auth.service.interface';
+import { ICreateCountryUseCase } from '@/application/use-cases/create-country.use-case';
+import { IAuthenticationService } from '@/application/services/auth.service.interface';
 import { countryPresenter } from '../presenters/country.presenter';
-import { UnauthenticatedError } from '@/src/entities/errors/auth';
-import { InputParseError } from '@/src/entities/errors/common';
+import { UnauthenticatedError } from '@/entities/errors/auth';
+import { InputParseError } from '@/entities/errors/common';
 import { z } from 'zod';
 
 const inputSchema = z.object({ name: z.string().min(1) });

--- a/src/interface-adapters/controllers/create-country.controller.ts
+++ b/src/interface-adapters/controllers/create-country.controller.ts
@@ -1,0 +1,26 @@
+import {
+    ICreateCountryUseCase,
+} from '@/src/application/use-cases/create-country.use-case';
+import { Country } from '@/src/entities/models/country';
+
+function presenter(countries: Country[]) {
+    return countries.map((country) => ({
+        id: country.id,
+        name: country.name,
+    }));
+}
+
+export type ICreateCountryController = ReturnType<
+    typeof createCountryController
+>;
+
+export const createCountryController =
+    (createCountryUseCase: ICreateCountryUseCase) => async (input: string) => {
+        // check authentication
+
+        // validate input
+        console.log('Input:', input);
+        const country = await createCountryUseCase(input);
+        return presenter([country]);
+        // call use case
+    };

--- a/src/interface-adapters/controllers/create-country.controller.ts
+++ b/src/interface-adapters/controllers/create-country.controller.ts
@@ -16,7 +16,7 @@ export const createCountryController =
         createCountryUseCase: ICreateCountryUseCase,
         authenticationService: IAuthenticationService,
     ) =>
-    async (input: { name: string }, sessionId: string) => {
+    async (input: z.infer<typeof inputSchema>, sessionId: string) => {
         // check authentication
         const isAuthenticated =
             await authenticationService.validateSession(sessionId);

--- a/src/interface-adapters/controllers/create-country.controller.ts
+++ b/src/interface-adapters/controllers/create-country.controller.ts
@@ -1,24 +1,43 @@
 import { ICreateCountryUseCase } from '@/src/application/use-cases/create-country.use-case';
-import { Country } from '@/src/entities/models/country';
+import { IAuthenticationService } from '@/src/application/services/auth.service.interface';
+import { countryPresenter } from '../presenters/country.presenter';
+import { UnauthenticatedError } from '@/src/entities/errors/auth';
+import { InputParseError } from '@/src/entities/errors/common';
+import { z } from 'zod';
 
-function presenter(countries: Country[]) {
-    return countries.map((country) => ({
-        id: country.id,
-        name: country.name,
-    }));
-}
+const inputSchema = z.object({ name: z.string().min(1) });
 
 export type ICreateCountryController = ReturnType<
     typeof createCountryController
 >;
 
 export const createCountryController =
-    (createCountryUseCase: ICreateCountryUseCase) => async (input: string) => {
+    (
+        createCountryUseCase: ICreateCountryUseCase,
+        authenticationService: IAuthenticationService,
+    ) =>
+    async (input: string, sessionId: string) => {
         // check authentication
+        const isAuthenticated =
+            await authenticationService.validateSession(sessionId);
+        if (!isAuthenticated) {
+            throw new UnauthenticatedError('User must be logged in.');
+        }
 
         // validate input
-        console.log('Input:', input);
-        const country = await createCountryUseCase(input);
-        return presenter([country]);
+        const { data, error: inputParseError } = inputSchema.safeParse(input);
+
+        if (inputParseError) {
+            throw new InputParseError('Invalid data', {
+                cause: inputParseError,
+            });
+        }
+
+        const { name } = data;
+
         // call use case
+        const country = await createCountryUseCase(name);
+
+        // format output
+        return countryPresenter([country]);
     };

--- a/src/interface-adapters/controllers/create-country.controller.ts
+++ b/src/interface-adapters/controllers/create-country.controller.ts
@@ -16,7 +16,7 @@ export const createCountryController =
         createCountryUseCase: ICreateCountryUseCase,
         authenticationService: IAuthenticationService,
     ) =>
-    async (input: string, sessionId: string) => {
+    async (input: { name: string }, sessionId: string) => {
         // check authentication
         const isAuthenticated =
             await authenticationService.validateSession(sessionId);

--- a/src/interface-adapters/controllers/create-country.controller.ts
+++ b/src/interface-adapters/controllers/create-country.controller.ts
@@ -1,6 +1,4 @@
-import {
-    ICreateCountryUseCase,
-} from '@/src/application/use-cases/create-country.use-case';
+import { ICreateCountryUseCase } from '@/src/application/use-cases/create-country.use-case';
 import { Country } from '@/src/entities/models/country';
 
 function presenter(countries: Country[]) {

--- a/src/interface-adapters/presenters/country.presenter.ts
+++ b/src/interface-adapters/presenters/country.presenter.ts
@@ -1,4 +1,4 @@
-import { Country } from '@/src/entities/models/country';
+import { Country } from '@/entities/models/country';
 
 export function countryPresenter(countries: Country[]) {
     return countries.map((country) => ({

--- a/src/interface-adapters/presenters/country.presenter.ts
+++ b/src/interface-adapters/presenters/country.presenter.ts
@@ -1,0 +1,8 @@
+import { Country } from '@/src/entities/models/country';
+
+export function countryPresenter(countries: Country[]) {
+    return countries.map((country) => ({
+        id: country.id,
+        name: country.name,
+    }));
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
             }
         ],
         "paths": {
-            "@/*": ["./*"]
+            "@/*": ["./src/*"]
         }
     },
     "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
             }
         ],
         "paths": {
-            "@/*": ["./src/*"]
+            "@/*": ["./src/*"],
+            "@/di/*": ["./di/*"]
         }
     },
     "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
I added the add countries stuff as example. So
- entity
- create country use case
- country repo interface
- country mock repo
- create country controller

for everythin to work i displayed how to use the dependency injection stuff

documentation and commonts on how stuff should be is still missing. e.g. where should authentication, authorization go. I also did not implement input parse checks yet. It is just for the structure and how the components interact with each other

i would like to discuss some stuff:
- theoretically it is apperently one controller for one use case
this leads to much boiler plate code but its one file does one shit. How do you think we should continue?
- i dared to make a unit test (but not commit it because i was afraid of getting in trouble)
i have to show this in person

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Create Country flow: validated input, session checks, creation, and formatted responses.

* **Improvements**
  * Introduced a validated country data model and clearer parsing/authentication errors.
  * Added typed interfaces for auth and country repository/use-case, plus a presenter for consistent output.
  * In-memory mocks for countries and authentication to aid testing.

* **Chores**
  * Added dependency-injection wiring and introduced a runtime validation library; updated path aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->