### PR TITLE
Rename all 'question' to 'problem'

### DIFF
--- a/app/components/ui/problem-card.tsx
+++ b/app/components/ui/problem-card.tsx
@@ -17,8 +17,8 @@ interface ProblemProps {
  *
  * @param description - The problem text to display.
  * @param variant - The display variant of the card (`'basic'` | `'withButtons'`). Default is `'basic'`.
- * @param onNext - Callback triggered when the "Another question" button is clicked (optional).
- * @param onPrevious - Callback triggered when the "Previous question" button is clicked (optional).
+ * @param onNext - Callback triggered when the "Another problem" button is clicked (optional).
+ * @param onPrevious - Callback triggered when the "Previous problem" button is clicked (optional).
  */
 export default function ProblemCard({
     description,

--- a/app/components/ui/sidebarMenu.tsx
+++ b/app/components/ui/sidebarMenu.tsx
@@ -116,9 +116,9 @@ export default function SidebarMenu({ onClose }: SidebarMenuProps) {
                     </button>
                 </div>
 
-                {/* Previously solved questions */}
+                {/* Previously solved problems */}
                 <p className="border-b pb-1 font-semibold">
-                    Previously solved questions:
+                    Previously solved problems:
                 </p>
             </div>
             <div className="mt-4 flex flex-col gap-4 overflow-y-auto">

--- a/app/protected/dashboard/page.tsx
+++ b/app/protected/dashboard/page.tsx
@@ -7,11 +7,11 @@ export default function DashboardPage() {
     return (
         <div className="flex min-h-screen flex-col items-center gap-6">
             <Header
-                variant="question"
-                mathQuestion={
+                variant="problem"
+                mathProblem={
                     <div className="flex h-52 w-[60%] items-center justify-center bg-[var(--card)]">
                         {' '}
-                        <h1>TODO: add math question component here</h1>
+                        <h1>TODO: add math problem component here</h1>
                     </div>
                 }
             />

--- a/app/protected/problem/page.tsx
+++ b/app/protected/problem/page.tsx
@@ -15,24 +15,24 @@ import Link from 'next/link';
  * @returns {JSX.Element} The rendered ProblemPage component.
  */
 export default function ProblemPage() {
-    const [questions, setQuestions] = useState([]);
+    const [problems, setProblems] = useState([]);
     const [currentIndex, setCurrentIndex] = useState(0);
     const [offset, setOffset] = useState(0);
     const [hasMore, setHasMore] = useState(true);
 
-    // TODO: Fetcing questions
-    // GET /api/questions?subjects=algebra,geometry&offset=0&limit=5
+    // TODO: Fetching problems
+    // GET /api/problems?subjects=algebra,geometry&offset=0&limit=5
     //   useEffect(() => {
-    //   fetchQuestions(offset);
+    //   fetchProblems(offset);
     // }, []);
 
     // const handleNext = () => {
     //   const nextIndex = currentIndex + 1;
-    //   if (nextIndex >= questions.length && hasMore) {
-    //     // No more local questions — fetch more
+    //   if (nextIndex >= problems.length && hasMore) {
+    //     // No more local problems — fetch more
     //     const newOffset = offset + 5;
     //     setOffset(newOffset);
-    //     fetchQuestions(newOffset);
+    //     fetchProblems(newOffset);
     //   }
     //   setCurrentIndex(nextIndex);
     // };
@@ -40,7 +40,7 @@ export default function ProblemPage() {
     // const handlePrevious = () => {
     //   if (currentIndex > 0) setCurrentIndex(currentIndex - 1);
     // };
-    //const currentQuestion = questions[currentIndex];
+    //const currentProblem = problems[currentIndex];
 
     //Just for mocking, will be removed when api are made
     const [description, setDescription] = useState(

--- a/app/protected/start/page.tsx
+++ b/app/protected/start/page.tsx
@@ -45,7 +45,7 @@ export default function StartPage() {
                             <SubjectSelect size="large" />
                         </div>
                         Ready? Then press {'"Start Practicing"'} and get your
-                        first math question.
+                        first math problem.
                     </CardContent>
                     <CardFooter>
                         <Button


### PR DESCRIPTION
PR https://github.com/TDT4290-Gr6/math-mate/pull/51 started renaming "question" to "problem", but it did not change all of them. That made `npm run build` fail (earlier than before), since `Header`'s `variant` "question" was changed to "problem", and "mathQuestion" was changed to "mathProblem", which was not respected in `app/protected/dashboard/page.tsx`.

This PR also changes all other occurrences of question, even in commented out code and comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated UI copy to use “problem” instead of “question” across the app.
  * Sidebar now labels history as “Previously solved problems.”
  * Dashboard header and related labels now use the “problem” variant.
  * Start page text updated to guide users to their “first math problem.”
  * Minor internal text/JSDoc adjustments with no functional impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->