### PR TITLE
Switch direction of relations between problems/methods/steps

### DIFF
--- a/src/entities/models/method.ts
+++ b/src/entities/models/method.ts
@@ -1,19 +1,20 @@
-import { problemSchema } from './problem';
+import { insertStepSchema, stepSchema } from './step';
 import { z } from 'zod';
 
 export const methodSchema = z.object({
     id: z.int(),
-    problemId: problemSchema.shape.id,
     title: z.string(),
     description: z.string(),
+    steps: z.array(stepSchema),
 });
 
 export type Method = z.infer<typeof methodSchema>;
 
-export const insertMethodSchema = methodSchema.pick({
-    problemId: true,
-    title: true,
-    description: true,
-});
+export const insertMethodSchema = methodSchema
+    .pick({
+        title: true,
+        description: true,
+    })
+    .extend({ steps: z.array(insertStepSchema) });
 
 export type MethodInsert = z.infer<typeof insertMethodSchema>;

--- a/src/entities/models/problem.ts
+++ b/src/entities/models/problem.ts
@@ -1,3 +1,4 @@
+import { insertMethodSchema, methodSchema } from './method';
 import { z } from 'zod';
 
 export const problemSchema = z.object({
@@ -7,16 +8,19 @@ export const problemSchema = z.object({
     solution: z.string(),
     subject: z.string(),
     level: z.int().min(1).max(5),
+    methods: z.array(methodSchema),
 });
 
 export type Problem = z.infer<typeof problemSchema>;
 
-export const insertProblemSchema = problemSchema.pick({
-    title: true,
-    problem: true,
-    solution: true,
-    subject: true,
-    level: true,
-});
+export const insertProblemSchema = problemSchema
+    .pick({
+        title: true,
+        problem: true,
+        solution: true,
+        subject: true,
+        level: true,
+    })
+    .extend({ methods: z.array(insertMethodSchema) });
 
 export type ProblemInsert = z.infer<typeof insertProblemSchema>;

--- a/src/entities/models/step.ts
+++ b/src/entities/models/step.ts
@@ -1,20 +1,14 @@
-import { problemSchema } from './problem';
-import { methodSchema } from './method';
 import { z } from 'zod';
 
 export const stepSchema = z.object({
     id: z.int(),
-    methodId: methodSchema.shape.id,
-    problemId: problemSchema.shape.id,
-    stepNumber: z.int().min(0),
+    stepNumber: z.int().min(1),
     content: z.string(),
 });
 
 export type Step = z.infer<typeof stepSchema>;
 
 export const insertStepSchema = stepSchema.pick({
-    methodId: true,
-    problemId: true,
     stepNumber: true,
     content: true,
 });


### PR DESCRIPTION
This will make it easier later, as problem will include all methods and steps, so we will not have to fix relations ourselves, since prisma can do it for us. See example fetching to the new Problem type:

```ts
const prismaProblem = await prisma.problem.findFirst({
    include: { Method: { include: { Step: true } } },
});

if (prismaProblem) {
    const problem: Problem = {
        id: prismaProblem.id,
        title: prismaProblem.title ?? undefined,
        problem: prismaProblem.problem,
        solution: prismaProblem.solution,
        subject: prismaProblem.subject,
        level: prismaProblem.level,
        methods: prismaProblem.Method.map((m) => ({
            id: m.id,
            title: m.title,
            description: m.description,
            steps: m.Step.map((s) => ({
                id: s.id,
                stepNumber: s.stepNumber,
                content: s.content,
            })),
        })),
    };
    console.log(problem);
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Problems now include associated methods, each with an ordered list of steps.
  - Create and edit flows support adding methods and steps together in one go.

- Refactor
  - Steps no longer require selecting a related problem or method; they’re managed within their parent method.
  - Step numbering now starts at 1 for clearer sequencing.
  - Data structure streamlined to better reflect nested relationships (Problem → Methods → Steps).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->