### PR TITLE
Use contrasting colors on country select

### DIFF
--- a/app/components/country-select.tsx
+++ b/app/components/country-select.tsx
@@ -45,7 +45,7 @@ export default function CountrySelect() {
                             titleComponent="span"
                         />
                     </DialogTitle>
-                    <DialogDescription>
+                    <DialogDescription className="text-foreground">
                         As this is a research project, we would like to know
                         what is your country of residence:
                     </DialogDescription>

--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -11,7 +11,7 @@ const buttonVariants = cva(
             variant: {
                 default: 'bg-primary text-primary-foreground',
                 secondary: 'bg-[var(--accent)] text-primary-foreground',
-                ghost: 'bg-[var(--sidebar-primary)]',
+                ghost: 'bg-sidebar-primary text-primary-foreground',
                 transparent: 'bg-transparent hover:bg-[var(--primary)]/10',
                 link: 'underline underline-offset-4',
             },


### PR DESCRIPTION
|Before|After|
|---|---|
|<img width="1045" height="559" alt="bilde" src="https://github.com/user-attachments/assets/384fb790-ad41-4254-a573-2ecb2be2214e" />|<img width="1026" height="546" alt="bilde" src="https://github.com/user-attachments/assets/7982d090-7180-4ed5-b3d5-e2f8aaf7832f" />|

Fixes #107 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated styling for the country selection dialog description text for improved visual consistency.
  * Refined ghost button styling for enhanced appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->