### PR TITLE
Integrate LaTeX formatting for answer display

### DIFF
--- a/app/components/answer-popup.tsx
+++ b/app/components/answer-popup.tsx
@@ -7,6 +7,7 @@ import {
     DialogHeader,
     DialogTitle,
 } from './ui/dialog';
+import { LaTeXFormattedText } from './ui/latex-formatted-text';
 import { useRouter } from 'next/navigation';
 import { useState, useEffect } from 'react';
 import { Button } from './ui/button';
@@ -139,7 +140,17 @@ export default function AnswerPopup({
                                             close you got.
                                         </p>
                                         <div className="my-3 h-12 rounded-md bg-[var(--answer-card-secondary)] px-4 py-3 text-[var(--secondary-foreground)]">
-                                            {answer}
+                                            <LaTeXFormattedText
+                                                text={
+                                                    (answer.startsWith('$')
+                                                        ? ''
+                                                        : '$') +
+                                                    answer +
+                                                    (answer.endsWith('$')
+                                                        ? ''
+                                                        : '$')
+                                                }
+                                            />
                                         </div>
                                         <p className="text-[var(--foreground)]">
                                             Did you arrive at the correct


### PR DESCRIPTION
|Before|After|
|---|---|
|<img width="1028" height="562" alt="bilde" src="https://github.com/user-attachments/assets/1f792e26-9cd3-48ce-afa7-05c7ead1a3e0" />|<img width="1042" height="565" alt="bilde" src="https://github.com/user-attachments/assets/c89eb10b-9856-466e-9f6a-4208edef33e2" />|
|<img width="1039" height="557" alt="bilde" src="https://github.com/user-attachments/assets/76971055-0e28-466a-bfbe-06b161a65d8e" />|<img width="1036" height="566" alt="bilde" src="https://github.com/user-attachments/assets/d7165503-61e4-48c3-8f96-d5caaeaaf1b6" />|
|<img width="1033" height="565" alt="bilde" src="https://github.com/user-attachments/assets/f584653f-9f9d-4a91-95b7-ec045b9c125c" />|<img width="1046" height="572" alt="bilde" src="https://github.com/user-attachments/assets/4e4d872f-c3e9-4c70-a1e3-413727dbb70e" />|



Fixes #118 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering of mathematical expressions in answer popups by applying LaTeX formatting to ensure proper display of formulas and mathematical notation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->