### PR TITLE
Display title in method card with LaTeX

### DIFF
--- a/app/components/ui/method-card.tsx
+++ b/app/components/ui/method-card.tsx
@@ -47,9 +47,10 @@ export default function MethodCard({
                 size={20}
             />
             {/* Title */}
-            <p className="border-border mt-[-26px] line-clamp-7 border-b pt-4 pb-2 text-sm font-semibold">
-                {title}
-            </p>
+            <LaTeXFormattedText
+                text={title}
+                className="border-border mt-[-26px] line-clamp-7 border-b pt-4 pb-2 text-sm font-semibold"
+            />
 
             {/* Description */}
             <div className="mt-2 mb-8">


### PR DESCRIPTION
Fixes #128 

Example: http://localhost:3000/protected/methods/36

|Before|After|
|---|---|
|<img width="352" height="344" alt="image" src="https://github.com/user-attachments/assets/92f18901-cde0-44ab-ae74-5ba8b9bbf3a1" />|<img width="342" height="340" alt="image" src="https://github.com/user-attachments/assets/52b81053-9699-4646-bb6d-71ce259d5bed" />|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering of method card titles to properly display mathematical notation and special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->