### PR TITLE
Get auth providers without api call

### DIFF
--- a/app/auth/signIn/page.tsx
+++ b/app/auth/signIn/page.tsx
@@ -7,9 +7,10 @@ export default async function SignInPage() {
     const providers: Provider[] = authOptions.providers;
 
     // serialize providers to a minimal array so we don't pass functions or complex objects
-    const serializedProviders = providers
-        ? Object.values(providers).map((p) => ({ id: p.id, name: p.name }))
-        : null;
+    const serializedProviders = providers.map((p) => ({
+        id: p.id,
+        name: p.name,
+    }));
 
     return (
         <main className="flex justify-center">


### PR DESCRIPTION
When building the project (`npm run build`), all server components are compiled. Thus, server component can't rely on any local endpoint that won't necessarily be up. This happens now in `app\auth\signIn\page.tsx`, where `await getProviders();` tries to fetch from `localhost:3000/api/auth/providers`, which of course is not up. So providers will not have a value, and it will be impossible to log in.

This PR fixes this by using the know values from the auth config, with no api call. This is possible, since it is a server component. When building and starting the server now, the auth works as intended :)

Fixes #149 

Proof it now works: see the screenshot in the report from lighthouse on this PR vs the report from main:

This PR: https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1760986910547-88845.report.html
Main: https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1760966248785-42143.report.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Sign-in provider loading was simplified to use a static configuration, improving sign-in page performance and reliability while keeping the visible sign-in experience unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->