### PR TITLE
Only display sign-in logo/color if configured

### DIFF
--- a/app/auth/signIn/SignInProviders.tsx
+++ b/app/auth/signIn/SignInProviders.tsx
@@ -4,7 +4,8 @@ import { Button } from '@/components/ui/button';
 import { FcGoogle } from 'react-icons/fc';
 import { FaGithub } from 'react-icons/fa';
 import { signIn } from 'next-auth/react';
-import { JSX } from 'react';
+import { cn } from '@/lib/utils';
+import type { JSX } from 'react';
 
 type Provider = {
     id: string;
@@ -39,14 +40,17 @@ export default function SignInProviders({
             {providers.map((provider) => (
                 <Button
                     key={provider.id}
-                    className={`flex w-60 items-center justify-center gap-4 font-semibold ${providerConfig[provider.id].color}`}
+                    className={cn(
+                        'flex w-60 items-center justify-center gap-4 font-semibold',
+                        providerConfig[provider.id]?.color,
+                    )}
                     onClick={() => {
                         signIn(provider.id, {
                             callbackUrl: '/protected/start',
                         });
                     }}
                 >
-                    {providerConfig[provider.id].icon}
+                    {providerConfig[provider.id]?.icon}
                     {provider.name}
                 </Button>
             ))}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -26,6 +26,8 @@ const providers: Provider[] = [
         clientId: process.env.NEXT_AUTH_GOOGLE_ID!,
         clientSecret: process.env.NEXT_AUTH_GOOGLE_SECRET!,
     }),
+    // When adding new providers, make sure to update the providerConfig in
+    // app/auth/signIn/SignInProviders.tsx as well
 ];
 
 // Make sure CYPRESS_TESTING is NOT 'true' in production


### PR DESCRIPTION
This PR adds optional chaining for retrieving color and logo for providers. This way, if it is not provided, building will not fail. See the error message in the issue this fixes. That is now gone.

This is how it will look when building/starting E2E. Production will not be affected.

<img width="394" height="382" alt="image" src="https://github.com/user-attachments/assets/b8279667-f700-43b3-a192-0227917622b7" />


Related #164 

Fixes #176 
