### PR TITLE
Use mocked chat service when E2E testing

### DIFF
--- a/di/modules/chat.module.ts
+++ b/di/modules/chat.module.ts
@@ -25,7 +25,10 @@ export const chatModule = () => {
     const chatModule = createModule();
 
     // Bind ChatService
-    if (process.env.NODE_ENV === 'test') {
+    if (
+        process.env.NODE_ENV === 'test' ||
+        process.env.CYPRESS_TESTING === 'true'
+    ) {
         chatModule.bind(DI_SYMBOLS.IChatService).toClass(MockChatService);
     } else {
         chatModule.bind(DI_SYMBOLS.IChatService).toClass(ChatService);


### PR DESCRIPTION
From related issue:
> We want the E2E tests to be as close to production as possible, but we should not use the real chat service when running tests. There are (at least) two reasons: it would be a direct cost when running tests (and if something goes wrong when testing, it could be a large expense), and even if we used the real chat service, we would not be able to evaluate if the responses are good. The only thing this would check is that the connection to OpenAI is working (admittedly this is important, but the cons outweigh the pros I think).

Fixes #178 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test environment detection to recognize additional testing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->